### PR TITLE
Use pure ruby for .cpu_count

### DIFF
--- a/bin/check-load.rb
+++ b/bin/check-load.rb
@@ -45,7 +45,7 @@ class LoadAverage
   end
 
   def cpu_count
-    `grep -sc ^processor /proc/cpuinfo`.to_i rescue 0
+    File.read('/proc/cpuinfo').scan(/^processor/).count rescue 0
   end
 
   def failed?


### PR DESCRIPTION
I need to do some benchmarks with this yet, but my guess is that the forking via the backticks is slower than doing a straight `File.read` in ruby.  It will also make this more portable as it doesn't rely on specific versions of `grep` for this to function properly.
