### PR TITLE
Remove Ruby 1.9.3 support; add Ruby 2.3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
 notifications:
   email:
     recipients:
@@ -26,8 +26,8 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
     repo: sensu-plugins/sensu-plugins-load-checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- Loosen dependency on sensu-plugin from `= 1.2.0` to `~> 1.2`
+- Update Rubocop to 0.40, apply auto-correct.
+
+### Removed
+- Removed Ruby 1.9.3 support; add Ruby 2.3.0 support to test matrix.
 
 ## [0.0.4] - 2015-12-11
-### Changed 
+### Changed
 - Use pure ruby for cpu count in check-load.rb
 
 ## [0.0.3] - 2015-07-14

--- a/Rakefile
+++ b/Rakefile
@@ -6,14 +6,7 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-desc 'Don\'t run Rubocop for unsupported versions'
-begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
-end
+args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
   OTHER_PATHS = %w().freeze

--- a/bin/check-load.rb
+++ b/bin/check-load.rb
@@ -23,19 +23,6 @@
 #   for details.
 #
 
-# round(n) doesn't exist in ruby < 1.9
-class Float
-  alias oldround round
-
-  def round(precision = nil)
-    if precision.nil? # rubocop:disable Style/GuardClause
-      return self
-    else
-      return (self * 10**precision).oldround.to_f / (10**precision)
-    end
-  end
-end
-
 require 'sensu-plugin/check/cli'
 
 class LoadAverage

--- a/bin/metrics-load.rb
+++ b/bin/metrics-load.rb
@@ -40,16 +40,6 @@
 require 'sensu-plugin/metric/cli'
 require 'socket'
 
-if RUBY_VERSION < '1.9.0'
-  require 'bigdecimal'
-
-  class Float
-    def round(val = 0)
-      BigDecimal.new(to_s).round(val).to_f
-    end
-  end
-end
-
 class LoadStat < Sensu::Plugin::Metric::CLI::Graphite
   option :scheme,
          description: 'Metric naming scheme, text to prepend to .$parent.$child',

--- a/sensu-plugins-load-checks.gemspec
+++ b/sensu-plugins-load-checks.gemspec
@@ -2,18 +2,10 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-load-checks'
-else
-  require_relative 'lib/sensu-plugins-load-checks'
-end
-
-# pvt_key = '~/.ssh/gem-private_key.pem'
+require_relative 'lib/sensu-plugins-load-checks'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
-  # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
   s.description            = 'This plugin provides native load instrumentation
                               for monitoring and metrics collection, including:
@@ -33,7 +25,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for load checks'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

This PR removes Ruby 1.9.3 support, and adds support for testing under Ruby 2.3.0, per the Sensu Plugins policy: 

> Ruby 1.9.3 (EOL): Linting is not done against it, and 1.9.3 will be supported where possible till Feb 2016 which is one year after EOL and 2 years after EOL was announced.
#### Known Compatibility Issues

Adds incompatibility with Ruby version < 2.0.0
