### PR TITLE
closes #11, #5 Fixes issues with LOCALE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+## [3.0.0]
+### Breaking Change
+- bin/check-load.rb remove option for per_core as its useless and broken (@majormoses)
+- bin/metrics-load.rb remove option for per_core as its useless and broken (@majormoses)
+
+### Changed
+- moved common logic into its own library location (@majormoses)
+### Fixed
+- bin/metrics-load.rb now uses common logic which fixes issues with uptime LOCALE parsing (@majormoses)
+
 ### [2.0.0]
 ### Breaking Change
 - bin/check-load.rb change the default of per_core to true (@majormoses)
-
 ### Changed
 - Use the `uptime` command in bin/check-load.rb as well (@smuth4)
 - Correctly detect the number of cores on BSD (@smuth4)
@@ -43,7 +52,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-load-checks/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-load-checks/compare/3.0.0...HEAD
+[3.0.0]: https://github.com/sensu-plugins/sensu-plugins-load-checks/compare/2.0.0...3.0.0
 [2.0.0]: https://github.com/sensu-plugins/sensu-plugins-load-checks/compare/1.0.0...2.0.0
 [1.0.0]: https://github.com/sensu-plugins/sensu-plugins-load-checks/compare/0.0.4...1.0.0
 [0.0.4]: https://github.com/sensu-plugins/sensu-plugins-load-checks/compare/0.0.3...0.0.4

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ To see the list of full options you can run:
 $ ./bin/check-load.rb --help
 Usage: ./bin/check-load.rb (options)
     -c, --crit L1,L5,L15             Load CRITICAL threshold, 1/5/15 min average
-    -p, --per-core                   Divide load average results by cpu/core count
     -w, --warn L1,L5,L15             Load WARNING threshold, 1/5/15 min average
 ```
 
-This check will only work on linux systems as it relies on `cat /proc/loadavg` and `cat /proc/cpuinfo`. The check now defaults to using the `per_core` option which will take the loadavg and divide by the number of cores. You can use `-w/-c` with a comma separated value for 1/5/15 minute thresholds.
+This check should work on linux systems and many other unix systems. The check takes the loadavg and divide by the number of cores. You can use `-w/-c` with a comma separated value for 1/5/15 minute thresholds.
 
 
 ## Installation

--- a/lib/sensu-plugins-load-checks/load-average.rb
+++ b/lib/sensu-plugins-load-checks/load-average.rb
@@ -1,0 +1,42 @@
+class LoadAverage
+  def initialize
+    @cores = cpu_count
+    @avg = load_avg
+  end
+
+  def load_avg
+    if File.exist?('/proc/loadavg')
+      # linux
+      File.read('/proc/loadavg').split.take(3).map { |a| (a.to_f / @cores).round(2) } rescue nil # rubocop:disable RescueModifier
+    else
+      # fallback for FreeBSD
+      `uptime`.split(' ')[-3..-1].map(&:to_f).map { |a| (a.to_f / @cores).round(2) } rescue nil # rubocop:disable RescueModifier
+    end
+  end
+
+  def cpu_count
+    if File.exist?('/proc/cpuinfo')
+      File.read('/proc/cpuinfo').scan(/^processor/).count
+    else
+      `sysctl -n hw.ncpu`.to_i
+    end
+  rescue
+    0
+  end
+
+  def failed?
+    @avg.nil? || @cores.zero?
+  end
+
+  def exceed?(thresholds)
+    @avg.zip(thresholds).any? { |a, t| a >= t }
+  end
+
+  def to_s
+    @avg.join(', ')
+  end
+
+  def total
+    @avg.map { |a| (a / @cores) }.join(', ')
+  end
+end

--- a/lib/sensu-plugins-load-checks/version.rb
+++ b/lib/sensu-plugins-load-checks/version.rb
@@ -1,6 +1,6 @@
 module SensuPluginsLoadChecks
   module Version
-    MAJOR = 2
+    MAJOR = 3
     MINOR = 0
     PATCH = 0
 


### PR DESCRIPTION
Breaking Change Release:
- Removed per-core option as the defaults changed and honestly I don't think they ever made sense. Without knowing the number of cores load averages are a useless metric to monitor.

Non Breaking Changes:
- moved common logic our of check-load.rb
- metrics-load.rb now use common logic
- fixed common logic for LOCALE

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Fix locale parsing issues. As part of this I moved the location of shared logic into a more sensible location.
#### Known Compatibility Issues
Option per_core is no longer used. This is a breaking change.
