### PR TITLE
Remove the comment explaining the per-cores flag from the merics-load.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- Remove the comment explaining the per-cores flag from the merics-load.rb file as this option no longer exists
 
 ### Fixed
 - use the `quick` tests as we want to not run all integration tests just the requested suites (@majormoses)

--- a/bin/metrics-load.rb
+++ b/bin/metrics-load.rb
@@ -9,10 +9,6 @@
 #   Load per processor
 #   ------------------
 #
-#   Optionally, with `--per-core`, this plugin will calculate load per
-#   processor from the raw load average by dividing load average by the number
-#   of processors.
-#
 #   The number of CPUs is determined by reading `/proc/cpuinfo`. This makes the
 #   feature Linux specific. Other OSs can be supported by adding OS # detection
 #   and a method to determine the number of CPUs.


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Addresses Issue #18 

#### General

- [x] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
As discussed in Issue #18 this comment refers to an option that no longer exists, and so to remove confusion has been removed

#### Known Compatibility Issues
None
