### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Changed
+- appeased the cops (@majormoses)
+
 ### Fixed
-- Remove the comment explaining the per-cores flag from the merics-load.rb file as this option no longer exists
+- Remove the comment explaining the per-cores flag from the merics-load.rb file as this option no longer exists (@AaronKalair)
 
 ### Fixed
 - use the `quick` tests as we want to not run all integration tests just the requested suites (@majormoses)

--- a/bin/metrics-load.rb
+++ b/bin/metrics-load.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
 
 #
 # DESCRIPTION:

--- a/lib/sensu-plugins-load-checks/load-average.rb
+++ b/lib/sensu-plugins-load-checks/load-average.rb
@@ -20,7 +20,7 @@ class LoadAverage
     else
       `sysctl -n hw.ncpu`.to_i
     end
-  rescue
+  rescue StandardError
     0
   end
 

--- a/sensu-plugins-load-checks.gemspec
+++ b/sensu-plugins-load-checks.gemspec
@@ -36,16 +36,16 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'bundler', '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
+  s.add_development_dependency 'kitchen-docker',            '~> 2.6'
+  s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
   # locked to keep ruby 2.1 support, this is pulled in by test-kitchen
   s.add_development_dependency 'mixlib-shellout', ['< 2.3.0', '~> 2.2']
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.49.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
-  s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'serverspec',                '~> 2.36.1'
   s.add_development_dependency 'test-kitchen',              '~> 1.6'
-  s.add_development_dependency 'kitchen-docker',            '~> 2.6'
-  s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
+  s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
While this one technically has a new enough version that it is unaffected we are bumping all of them to `~> 0.51.0` so for consistency sake we will bump this as well.

Misc:
- appease the cops
- minor changelog fixup

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [x] Update Changelog following the conventions laid out  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
While it is technically not vulnerable updating to same version as others for consistency. 
#### Known Compatibility Issues
none